### PR TITLE
API Problem - updateProblem endpoint

### DIFF
--- a/src/main/java/com/example/aplicacion/controllers/api_controllers/APIProblemController.java
+++ b/src/main/java/com/example/aplicacion/controllers/api_controllers/APIProblemController.java
@@ -118,13 +118,20 @@ public class APIProblemController {
 
     @ApiOperation("Update a problem with Request Param")
     @PutMapping("problem/{problemId}")
-    public ResponseEntity<ProblemAPI> updateProblem(@PathVariable String problemId, @RequestParam(required = false) Optional<String> problemName, @RequestParam(required = false) Optional<String> teamId, @RequestParam(required = false) Optional<String> timeout, @RequestParam(required = false) Optional<byte[]> pdf) {
+    public ResponseEntity<ProblemAPI> updateProblem(@PathVariable String problemId, @RequestParam(required = false) Optional<String> problemName,
+                                                    @RequestParam(required = false) Optional<String> teamId,
+                                                    @RequestParam(required = false) Optional<String> timeout,
+                                                    @RequestPart(name="pdf", required=false) MultipartFile pdf) throws IOException {
         problemId = sanitize(problemId);
         problemName = sanitize(problemName);
         teamId = sanitize(teamId);
         timeout = sanitize(timeout);
-
-        ProblemString salida = problemService.updateProblemMultipleOptionalParams(problemId, problemName, teamId, pdf, timeout);
+        byte[] pdfBytes = null;
+        if(pdf!=null){
+            pdfBytes = pdf.getBytes();
+        }
+        Optional<byte[]> optPdfBytes = Optional.ofNullable(pdfBytes);
+        ProblemString salida = problemService.updateProblemMultipleOptionalParams(problemId, problemName, teamId, optPdfBytes, timeout);
         if (salida.getSalida().equals("OK")) {
             return new ResponseEntity<>(salida.getProblem().toProblemAPI(), HttpStatus.OK);
         } else {


### PR DESCRIPTION
Buenas @rmartinsanta @Sourius @isaaclo97 @jmcolmenar ,  

he realizado este cambio para que desde front sea mas sencillo mandar el pdf a la hora de actualizar el problema,
 y convertirlo a lo que necesita el back, aunque diría que es mejor tocar el servicio para que no haya esa lógica de convertirlo a un array de bytes en el controller.

Si por lo que sea no os gusta o no sirve por algun motivo me comentais para ver que mas puedo hacer en el front.

Un saludo. 