### PR TITLE
Actalización a SpringBoot 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,5 @@ build/
 .vscode/
 .DS_Store
 
-*.secret
-
+### iudex ENV files ###
 secrets.env

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>
         </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.github.docker-java</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <version>5.2.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,12 @@
             <artifactId>docker-java-transport-httpclient5</artifactId>
             <version>3.3.3</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-transport-httpclient5</artifactId>
+            <version>3.3.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.14</version>
+        <version>3.1.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RolesAllowed;
 import java.util.List;
 
 @RestController

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@CrossOrigin(methods = {RequestMethod.DELETE, RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT})
 public class APIAdminController {
 
     @Autowired

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
@@ -4,13 +4,12 @@ import es.urjc.etsii.grafo.iudex.entities.Result;
 import es.urjc.etsii.grafo.iudex.services.ResultService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.annotation.security.RolesAllowed;
 import java.util.List;
 
 @RestController
@@ -22,7 +21,7 @@ public class APIAdminController {
 
     @Operation( summary = "Get a full Result")
     @GetMapping("/API/v1/result/{resultId}")
-    @RolesAllowed("ROLE_ADMIN")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<Result> getResult(@PathVariable String resultId) {
         resultId = Sanitizer.removeLineBreaks(resultId);
 
@@ -35,7 +34,7 @@ public class APIAdminController {
 
     @Operation( summary = "Get all Results")
     @GetMapping("/API/v1/result/")
-    @RolesAllowed("ROLE_ADMIN")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<List<Result>> getAllResult() {
         List<Result> resultList = resultService.getAllResults();
         if (resultList == null) {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RolesAllowed;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/API/v1/")
-@CrossOrigin(methods = {RequestMethod.DELETE, RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT})
 public class APIContestController {
 
     @Autowired

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
@@ -7,15 +7,14 @@ import es.urjc.etsii.grafo.iudex.pojos.TeamScore;
 import es.urjc.etsii.grafo.iudex.services.ContestService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.annotation.security.RolesAllowed;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +29,7 @@ public class APIContestController {
 
     @Operation( summary = "Return all contests")
     @GetMapping("contest")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<List<ContestAPI>> getAllcontests() {
         List<Contest> contestList = contestService.getAllContests();
         List<ContestAPI> contestAPIS = new ArrayList<>();
@@ -42,7 +41,7 @@ public class APIContestController {
 
     @Operation( summary = "Return Page Contest")
     @GetMapping("contest/page")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<Page<ContestAPI>> getAllContestPage(Pageable pageable) {
         Page<ContestAPI> salida = contestService.getContestPage(pageable).map(Contest::toContestAPI);
         return new ResponseEntity<>(salida, HttpStatus.OK);
@@ -50,7 +49,7 @@ public class APIContestController {
 
     @Operation( summary = "Return selected contest with full Problems")
     @GetMapping("contest/{contestId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<ContestAPI> getContest(@PathVariable String contestId) {
         contestId = Sanitizer.removeLineBreaks(contestId);
 
@@ -68,7 +67,7 @@ public class APIContestController {
 
     @Operation( summary = "Create a contest")
     @PostMapping("contest")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<ContestAPI> addContest(@RequestParam String contestName, @RequestParam String teamId, @RequestParam Optional<String> descripcion, @RequestParam long startTimestamp, @RequestParam long endTimestamp) {
         contestName = Sanitizer.removeLineBreaks(contestName);
         teamId = Sanitizer.removeLineBreaks(teamId);
@@ -84,7 +83,7 @@ public class APIContestController {
 
     @Operation( summary = "Delete a contest")
     @DeleteMapping("contest/{contestId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> deleteContest(@PathVariable String contestId) {
         contestId = Sanitizer.removeLineBreaks(contestId);
         String salida = contestService.deleteContest(contestId);
@@ -97,7 +96,7 @@ public class APIContestController {
 
     @Operation( summary = "Update a contest")
     @PutMapping("contest/{contestId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<ContestAPI> updateContest(@PathVariable String contestId, @RequestParam Optional<String> contestName, @RequestParam Optional<String> teamId, @RequestParam Optional<String> descripcion, @RequestParam Optional<Long> startTimestamp, @RequestParam Optional<Long> endTimestamp) {
         contestId = Sanitizer.removeLineBreaks(contestId);
         contestName = Sanitizer.removeLineBreaks(contestName);
@@ -114,7 +113,7 @@ public class APIContestController {
 
     @Operation( summary = "Add Problem to Contest")
     @PutMapping("contest/{contestId}/{problemId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> addProblemToContest(@PathVariable String problemId, @PathVariable String contestId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         contestId = Sanitizer.removeLineBreaks(contestId);
@@ -129,7 +128,7 @@ public class APIContestController {
 
     @Operation( summary = "Delete a Problem from a Contest")
     @DeleteMapping("contest/{contestId}/{problemId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> deleteProblemFromContest(@PathVariable String problemId, @PathVariable String contestId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         contestId = Sanitizer.removeLineBreaks(contestId);
@@ -144,7 +143,7 @@ public class APIContestController {
 
     @Operation( summary = "Add Team to Contest")
     @PutMapping("contest/{contestId}/team/{teamId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<String> addTeamToContest(@PathVariable String contestId, @PathVariable String teamId) {
         contestId = Sanitizer.removeLineBreaks(contestId);
         teamId = Sanitizer.removeLineBreaks(teamId);
@@ -159,7 +158,7 @@ public class APIContestController {
 
     @Operation( summary = "Bulk add Team to Contest")
     @PutMapping("contest/{contestId}/team/addBulk")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> addTeamToContest(@PathVariable String contestId, @RequestParam String[] teamList) {
         contestId = Sanitizer.removeLineBreaks(contestId);
 
@@ -173,7 +172,7 @@ public class APIContestController {
 
     @Operation( summary = "Delete Team From Contest")
     @DeleteMapping("contest/{contestId}/team/{teamId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> deleteTeamFromContest(@PathVariable String contestId, @PathVariable String teamId) {
         contestId = Sanitizer.removeLineBreaks(contestId);
         teamId = Sanitizer.removeLineBreaks(teamId);
@@ -201,7 +200,7 @@ public class APIContestController {
 
     @Operation( summary = "Add Language to Contest")
     @PostMapping("contest/{contestId}/language")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> addLanguageToContest(@PathVariable String contestId, @RequestParam String language) {
         contestId = Sanitizer.removeLineBreaks(contestId);
         language = Sanitizer.removeLineBreaks(language);
@@ -228,7 +227,7 @@ public class APIContestController {
 
     @Operation( summary = "Set accepted languages of a contest")
     @PostMapping("contest/{contestId}/language/addBulk")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> addAcceptedLanguagesToContest(@PathVariable String contestId, @RequestParam String[] languageList) {
         contestId = Sanitizer.removeLineBreaks(contestId);
 
@@ -241,7 +240,7 @@ public class APIContestController {
 
     @Operation( summary = "Get scores of a contest")
     @GetMapping("contest/{contestId}/scoreboard")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<List<TeamScore>> getScores(@PathVariable String contestId) {
         contestId = Sanitizer.removeLineBreaks(contestId);
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIErrorController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIErrorController.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestControllerAdvice
-@CrossOrigin(methods = {RequestMethod.DELETE, RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT})
 public class APIErrorController {
     private static final Logger logger = LoggerFactory.getLogger(APIErrorController.class);
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIErrorController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIErrorController.java
@@ -10,6 +10,13 @@ import org.springframework.web.bind.annotation.*;
 public class APIErrorController {
     private static final Logger logger = LoggerFactory.getLogger(APIErrorController.class);
 
+    @ExceptionHandler({ org.springframework.security.access.AccessDeniedException.class })
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public String handleAccessDeniedException(org.springframework.security.access.AccessDeniedException e) {
+        logger.error(e.toString());
+        return "UNAUTHORIZED";
+    }
+
     @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public String handleError(RuntimeException e) {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIErrorController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIErrorController.java
@@ -13,14 +13,14 @@ public class APIErrorController {
     @ExceptionHandler({ org.springframework.security.access.AccessDeniedException.class })
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public String handleAccessDeniedException(org.springframework.security.access.AccessDeniedException e) {
-        logger.error(e.toString());
+        if (logger.isErrorEnabled()) logger.error(e.toString(), e);
         return "UNAUTHORIZED";
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public String handleError(RuntimeException e) {
-        logger.error(e.toString());
+        if (logger.isErrorEnabled()) logger.error(e.toString(), e);
         return "ERROR GENERAL DEL SISTEMA";
     }
 }

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/API/v1/")
-@CrossOrigin(methods = {RequestMethod.GET})
 public class APILanguageController {
     @Autowired
     private LanguageService languageService;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RolesAllowed;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
@@ -4,13 +4,12 @@ import es.urjc.etsii.grafo.iudex.entities.Language;
 import es.urjc.etsii.grafo.iudex.pojos.LanguageAPI;
 import es.urjc.etsii.grafo.iudex.services.LanguageService;
 import io.swagger.v3.oas.annotations.Operation;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.annotation.security.RolesAllowed;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +22,7 @@ public class APILanguageController {
 
     @Operation( summary = "Return all languages")
     @GetMapping("language")
-    @RolesAllowed("ROLE_ADMIN")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<List<LanguageAPI>> getLanguages() {
         List<Language> languageList = languageService.getAllLanguages();
         List<LanguageAPI> languageAPIS = new ArrayList<>();

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
@@ -1,7 +1,5 @@
 package es.urjc.etsii.grafo.iudex.api.v1;
 
-import es.urjc.etsii.grafo.iudex.entities.User;
-import es.urjc.etsii.grafo.iudex.exceptions.IudexException;
 import es.urjc.etsii.grafo.iudex.security.jwt.AuthResponse;
 import es.urjc.etsii.grafo.iudex.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,8 +19,9 @@ public class APIOAuthController {
     private UserService userService;
 
     @GetMapping("/login")
-    public ResponseEntity<AuthResponse> session(@AuthenticationPrincipal OidcUser oidcUser) {
-        AuthResponse authResponse = userService.loginUser(oidcUser);
+    @PreAuthorize("hasAuthority('OIDC_USER')")
+    public ResponseEntity<AuthResponse> session(@AuthenticationPrincipal OAuth2User oAuth2User) {
+        AuthResponse authResponse = userService.loginUser(oAuth2User);
 
         if (authResponse.getError() != null) return new ResponseEntity<>(authResponse, HttpStatus.OK);
         else return new ResponseEntity<>(authResponse, HttpStatus.BAD_REQUEST);

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
@@ -23,7 +23,7 @@ public class APIOAuthController {
     public ResponseEntity<AuthResponse> session(@AuthenticationPrincipal OAuth2User oAuth2User) {
         AuthResponse authResponse = userService.loginUser(oAuth2User);
 
-        if (authResponse.getError() != null) return new ResponseEntity<>(authResponse, HttpStatus.OK);
+        if (authResponse.getError() == null) return new ResponseEntity<>(authResponse, HttpStatus.OK);
         else return new ResponseEntity<>(authResponse, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
@@ -11,7 +11,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@CrossOrigin(methods = { RequestMethod.GET })
 @RequestMapping("/API/v1/oauth")
 public class APIOAuthController {
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
@@ -6,16 +6,15 @@ import es.urjc.etsii.grafo.iudex.pojos.ProblemString;
 import es.urjc.etsii.grafo.iudex.services.ProblemService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-
+import jakarta.ws.rs.Consumes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import jakarta.annotation.security.RolesAllowed;
-import jakarta.ws.rs.Consumes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,7 @@ public class APIProblemController {
     //Get all problems in DB
     @Operation( summary = "Return All Problems")
     @GetMapping("problem")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<List<ProblemAPI>> problems() {
         List<Problem> problems = problemService.getAllProblemas();
         List<ProblemAPI> salida = new ArrayList<>();
@@ -44,7 +43,7 @@ public class APIProblemController {
 
     @Operation( summary = "Return Page of all Problems")
     @GetMapping("problem/page")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<Page<ProblemAPI>> getAllProblemPage(Pageable pageable) {
         return new ResponseEntity<>(problemService.getProblemsPage(pageable).map(Problem::toProblemAPI), HttpStatus.OK);
     }
@@ -52,7 +51,7 @@ public class APIProblemController {
     //GetProblem
     @Operation( summary = "Return selected problem")
     @GetMapping("problem/{problemId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<ProblemAPI> getProblem(@PathVariable String problemId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
 
@@ -81,7 +80,7 @@ public class APIProblemController {
     @Operation( summary = "Create Problem from Zip")
     @Consumes(MediaType.MULTIPART_FORM_DATA_VALUE)
     @PostMapping(value = "problem/fromZip")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<ProblemAPI> createProblemFromZip(@RequestPart("file") MultipartFile file, @RequestParam(required = false) String problemName, @RequestParam String teamId, @RequestParam String contestId) {
         problemName = Sanitizer.removeLineBreaks(problemName);
         teamId = Sanitizer.removeLineBreaks(teamId);
@@ -101,7 +100,7 @@ public class APIProblemController {
 
     @Operation( summary = "Update problem from ZIP")
     @PutMapping(value = "problem/{problemId}/fromZip", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<ProblemAPI> updateProblemFromZip(@PathVariable String problemId, @RequestPart("file") MultipartFile file, @RequestParam String problemName, @RequestParam String teamId, @RequestParam String contestId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         problemName = Sanitizer.removeLineBreaks(problemName);
@@ -123,7 +122,7 @@ public class APIProblemController {
 
     @Operation( summary = "Update a problem with Request Param")
     @PutMapping("problem/{problemId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<ProblemAPI> updateProblem(@PathVariable String problemId, @RequestParam(required = false) Optional<String> problemName, @RequestParam(required = false) Optional<String> teamId, @RequestParam(required = false) Optional<String> timeout, @RequestPart(name = "pdf", required = false) MultipartFile pdf) throws IOException {
         problemId = Sanitizer.removeLineBreaks(problemId);
         problemName = Sanitizer.removeLineBreaks(problemName);
@@ -141,7 +140,7 @@ public class APIProblemController {
     //Controller que devuelve en un HTTP el pdf del problema pedido
     @Operation( summary = "Get pdf from Problem")
     @GetMapping("problem/{problemId}/getPDF")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<byte[]> goToProblem2(@PathVariable String problemId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
 
@@ -165,7 +164,7 @@ public class APIProblemController {
 
     @Operation( summary = "Delete problem from all contests")
     @DeleteMapping("problem/{problemId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> deleteProblem(@PathVariable String problemId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
 
@@ -179,7 +178,7 @@ public class APIProblemController {
 
     @Operation( summary = "Add sample to problem")
     @PostMapping("problem/{problemId}/sample")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> addSampleToProblem(@PathVariable String problemId, @RequestParam String name, @RequestPart("entrada") MultipartFile sampleInput, @RequestPart("salida") MultipartFile sampleOutput, @RequestParam boolean isPublic) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         name = Sanitizer.removeLineBreaks(name);
@@ -200,7 +199,7 @@ public class APIProblemController {
 
     @Operation( summary = "Update sample from problem")
     @PutMapping("problem/{problemId}/sample/{sampleId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> updateSampleFromProblem(@PathVariable String problemId, @PathVariable String sampleId, @RequestParam(value = "name", required = false) Optional<String> nameOptional, @RequestPart(value = "entrada", required = false) Optional<MultipartFile> sampleInputOptional, @RequestPart(value = "salida", required = false) Optional<MultipartFile> sampleOutputOptional, @RequestParam(value = "isPublic", required = false) Optional<Boolean> isPublicOptional) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         sampleId = Sanitizer.removeLineBreaks(sampleId);
@@ -237,7 +236,7 @@ public class APIProblemController {
 
     @Operation( summary = "Delete sample from problem")
     @DeleteMapping("problem/{problemId}/sample/{sampleId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> deleteSampleFromProblem(@PathVariable String problemId, @PathVariable String sampleId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         sampleId = Sanitizer.removeLineBreaks(sampleId);

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
@@ -14,8 +14,8 @@ import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.Consumes;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/API/v1/")
-@CrossOrigin(methods = {RequestMethod.DELETE, RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT})
 public class APIProblemController {
 
     @Autowired

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(methods = {RequestMethod.DELETE, RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT})
 public class APISubmissionController {
 
     @Autowired

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
@@ -12,8 +12,7 @@ import es.urjc.etsii.grafo.iudex.services.ProblemService;
 import es.urjc.etsii.grafo.iudex.services.SubmissionService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-
-import org.apache.commons.io.FilenameUtils;
+import jakarta.annotation.security.RolesAllowed;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +21,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.annotation.security.RolesAllowed;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
@@ -12,12 +12,12 @@ import es.urjc.etsii.grafo.iudex.services.ProblemService;
 import es.urjc.etsii.grafo.iudex.services.SubmissionService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.annotation.security.RolesAllowed;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,7 +41,7 @@ public class APISubmissionController {
 
     @Operation( summary = "Get List of submission given problem, contest or both at the same time")
     @GetMapping("/API/v1/submissions")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<List<SubmissionAPI>> getSubmissions(@RequestParam(required = false) Optional<String> contestId, @RequestParam(required = false) Optional<String> problemId) {
         contestId = Sanitizer.removeLineBreaks(contestId);
         problemId = Sanitizer.removeLineBreaks(problemId);
@@ -104,7 +104,7 @@ public class APISubmissionController {
 
     @Operation( summary = "Return Page of all submissions")
     @GetMapping("/API/v1/submission/page")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<Page<SubmissionAPI>> getAllSubmisionPage(Pageable pageable) {
         return new ResponseEntity<>(submissionService.getSubmissionsPage(pageable).map(Submission::toSubmissionAPI), HttpStatus.OK);
     }
@@ -112,7 +112,7 @@ public class APISubmissionController {
 
     @Operation( summary = "Get submission with results")
     @GetMapping("/API/v1/submission/{submissionId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<SubmissionAPI> getSubmission(@PathVariable String submissionId) {
         submissionId = Sanitizer.removeLineBreaks(submissionId);
 
@@ -127,7 +127,7 @@ public class APISubmissionController {
 
     @Operation( summary = "Create a submission to a problem and contest")
     @PostMapping("/API/v1/submission")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<SubmissionAPI> createSubmission(@RequestParam String problemId, @RequestParam String contestId, @RequestParam MultipartFile codigo, @RequestParam String lenguaje, @RequestParam String teamId) {
         problemId = Sanitizer.removeLineBreaks(problemId);
         contestId = Sanitizer.removeLineBreaks(contestId);
@@ -150,7 +150,7 @@ public class APISubmissionController {
 
     @Operation( summary = "Delete API")
     @DeleteMapping("/API/v1/submission/{submissionId}")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<String> deleteSubmission(@PathVariable String submissionId) {
         submissionId = Sanitizer.removeLineBreaks(submissionId);
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(methods = {RequestMethod.DELETE, RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT})
 public class APITeamController {
     @Autowired
     UserAndTeamService teamService;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RolesAllowed;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
@@ -4,16 +4,14 @@ import es.urjc.etsii.grafo.iudex.entities.Team;
 import es.urjc.etsii.grafo.iudex.pojos.TeamAPI;
 import es.urjc.etsii.grafo.iudex.pojos.TeamString;
 import es.urjc.etsii.grafo.iudex.services.UserAndTeamService;
-
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.annotation.security.RolesAllowed;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +24,7 @@ public class APITeamController {
 
     @Operation( summary = "Return all Teams")
     @GetMapping("/API/v1/team")
-    @RolesAllowed("ROLE_JUDGE")
+    @PreAuthorize("hasAuthority('ROLE_JUDGE')")
     public ResponseEntity<List<TeamAPI>> getteams() {
         List<TeamAPI> teamAPIS = new ArrayList<>();
         for (Team team : teamService.getAllTeams()) {
@@ -37,7 +35,7 @@ public class APITeamController {
 
     @Operation( summary = "Return Team")
     @GetMapping("/API/v1/team/{teamId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<TeamAPI> getTeam(@PathVariable String teamId) {
         teamId = Sanitizer.removeLineBreaks(teamId);
 
@@ -52,7 +50,7 @@ public class APITeamController {
 
     @Operation( summary = "Creates a Team")
     @PostMapping("/API/v1/team")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<TeamAPI> createTeam(@RequestParam String nombreEquipo) {
         nombreEquipo = Sanitizer.removeLineBreaks(nombreEquipo);
 
@@ -68,7 +66,7 @@ public class APITeamController {
 
     @Operation( summary = "Delete a Team")
     @DeleteMapping("/API/v1/team/{teamId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<String> deleteTeam(@PathVariable String teamId) {
         teamId = Sanitizer.removeLineBreaks(teamId);
 
@@ -82,7 +80,7 @@ public class APITeamController {
 
     @Operation( summary = "Update a Team")
     @PutMapping("/API/v1/team/{teamId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<TeamAPI> updateTeam(@PathVariable String teamId, @RequestParam(required = false) Optional<String> teamName) {
         teamId = Sanitizer.removeLineBreaks(teamId);
         teamName = Sanitizer.removeLineBreaks(teamName);
@@ -97,7 +95,7 @@ public class APITeamController {
 
     @Operation( summary = "Add user to Team")
     @PutMapping("/API/v1/team/{teamId}/{userId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<TeamAPI> addUserToTeam(@PathVariable String teamId, @PathVariable String userId) {
         teamId = Sanitizer.removeLineBreaks(teamId);
         userId = Sanitizer.removeLineBreaks(userId);
@@ -112,7 +110,7 @@ public class APITeamController {
 
     @Operation( summary = "Delete user from team")
     @DeleteMapping("/API/v1/team/{teamId}/{userId}")
-    @RolesAllowed("ROLE_USER")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<String> deleteUserFromTeam(@PathVariable String teamId, @PathVariable String userId) {
         teamId = Sanitizer.removeLineBreaks(teamId);
         userId = Sanitizer.removeLineBreaks(userId);

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
@@ -1,18 +1,13 @@
 package es.urjc.etsii.grafo.iudex.api.v1;
 
 import es.urjc.etsii.grafo.iudex.entities.User;
-import es.urjc.etsii.grafo.iudex.pojos.UserAPI;
-import es.urjc.etsii.grafo.iudex.pojos.UserString;
 import es.urjc.etsii.grafo.iudex.services.UserAndTeamService;
-import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.annotation.security.RolesAllowed;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +20,7 @@ public class APIUserController {
 
     @Operation( summary = "Add a specific role to an existing user")
     @PostMapping("/API/v1/user/{id}/role/{role}")
-    @RolesAllowed("ROLE_ADMIN")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<List<String>> addRoleToUser(@PathVariable long id, @PathVariable String role) {
         Optional<User> optionalUser = userAndTeamService.getUserById(id);
         if (optionalUser.isEmpty()) return ResponseEntity.notFound().build();
@@ -42,7 +37,7 @@ public class APIUserController {
 
     @Operation( summary = "Remove a role from an existing user")
     @DeleteMapping("/API/v1/user/{id}/role/{role}")
-    @RolesAllowed("ROLE_ADMIN")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<List<String>> removeRoleFromUser(@PathVariable long id, @PathVariable String role) {
         Optional<User> optionalUser = userAndTeamService.getUserById(id);
         if (optionalUser.isEmpty()) return ResponseEntity.notFound().build();

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RolesAllowed;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(methods = {RequestMethod.POST})
 public class APIUserController {
 
     @Autowired

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Contest.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Contest.java
@@ -5,7 +5,7 @@ import es.urjc.etsii.grafo.iudex.pojos.LanguageAPI;
 import es.urjc.etsii.grafo.iudex.pojos.ProblemAPI;
 import es.urjc.etsii.grafo.iudex.pojos.TeamAPI;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.*;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Contest.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Contest.java
@@ -26,7 +26,7 @@ public class Contest {
     @OneToMany(mappedBy = "contest")
     private Set<ContestProblem> listaProblemas;
 
-    @OneToMany(mappedBy= "lenguajes")
+    @OneToMany(mappedBy= "contest")
     private Set<ContestLanguages> lenguajes;
 
     @OneToMany(mappedBy = "contest")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/ContestLanguages.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/ContestLanguages.java
@@ -1,9 +1,9 @@
 package es.urjc.etsii.grafo.iudex.entities;
 
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
-
-import javax.persistence.*;
 
 @Entity
 public class  ContestLanguages {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/ContestProblem.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/ContestProblem.java
@@ -2,7 +2,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class ContestProblem {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/ContestTeams.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/ContestTeams.java
@@ -3,7 +3,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class ContestTeams {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Language.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Language.java
@@ -2,7 +2,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 
 import es.urjc.etsii.grafo.iudex.pojos.LanguageAPI;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Problem.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Problem.java
@@ -5,7 +5,7 @@ import es.urjc.etsii.grafo.iudex.pojos.SampleAPI;
 import es.urjc.etsii.grafo.iudex.pojos.SubmissionAPI;
 import com.google.common.hash.Hashing;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Result.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Result.java
@@ -2,7 +2,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 
 import es.urjc.etsii.grafo.iudex.pojos.ResultAPI;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Objects;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Sample.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Sample.java
@@ -2,7 +2,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 
 import es.urjc.etsii.grafo.iudex.pojos.SampleAPI;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Objects;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Submission.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Submission.java
@@ -4,7 +4,7 @@ import es.urjc.etsii.grafo.iudex.pojos.ResultAPI;
 import es.urjc.etsii.grafo.iudex.pojos.SubmissionAPI;
 import com.google.common.hash.Hashing;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/SubmissionProblemValidator.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/SubmissionProblemValidator.java
@@ -1,6 +1,6 @@
 package es.urjc.etsii.grafo.iudex.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Team.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Team.java
@@ -20,7 +20,7 @@ public class Team {
     private Set<TeamUser> participantes;
     private boolean esUser;
     
-    @OneToMany(mappedBy = "contest")
+    @OneToMany
     Set<ContestProblem> listaProblemas;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/Team.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/Team.java
@@ -2,7 +2,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 
 import es.urjc.etsii.grafo.iudex.pojos.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.*;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/TeamUser.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/TeamUser.java
@@ -3,7 +3,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class TeamUser {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/TeamsProblems.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/TeamsProblems.java
@@ -3,7 +3,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class TeamsProblems {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/entities/User.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/entities/User.java
@@ -3,7 +3,7 @@ package es.urjc.etsii.grafo.iudex.entities;
 
 import es.urjc.etsii.grafo.iudex.pojos.UserAPI;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/exceptions/JwtIudexException.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/exceptions/JwtIudexException.java
@@ -1,0 +1,9 @@
+package es.urjc.etsii.grafo.iudex.exceptions;
+
+public class JwtIudexException extends RuntimeException {
+
+    public JwtIudexException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/pojos/ProblemScore.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/pojos/ProblemScore.java
@@ -1,6 +1,6 @@
 package es.urjc.etsii.grafo.iudex.pojos;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.Objects;
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/pojos/TeamScore.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/pojos/TeamScore.java
@@ -2,7 +2,7 @@ package es.urjc.etsii.grafo.iudex.pojos;
 
 import es.urjc.etsii.grafo.iudex.entities.Problem;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.*;
 
 public class TeamScore {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
@@ -5,8 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
@@ -17,8 +17,7 @@ class ConfigSecurity {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/API/v1/oauth/**")
-                        .authenticated())
+                        .anyRequest().authenticated())
                 .oauth2Login(Customizer.withDefaults());
 
         // Disable CORS and CSRF protection

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
@@ -2,7 +2,8 @@ package es.urjc.etsii.grafo.iudex.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -10,19 +11,18 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(jsr250Enabled=true)
+@EnableMethodSecurity(jsr250Enabled=true)
 class ConfigSecurity {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests()
-                .antMatchers("/API/v1/oauth/**")
-                .authenticated()
-                .and()
-                .oauth2Login();
+        http.authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/API/v1/oauth/**")
+                        .authenticated())
+                .oauth2Login(Customizer.withDefaults());
 
         // Disable CORS and CSRF protection
-        http.cors().and().csrf().disable();
+        http.cors(AbstractHttpConfigurer::disable).csrf(AbstractHttpConfigurer::disable);
 
         return http.build();
     }

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtRequestFilter.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
@@ -1,19 +1,16 @@
 package es.urjc.etsii.grafo.iudex.security.jwt;
 
-import es.urjc.etsii.grafo.iudex.exceptions.JwtIudexException;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -23,27 +20,9 @@ public class JwtTokenProvider {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(JwtTokenProvider.class);
 
-	private final String jwtSecret = getJwtSecret();
-
 	private static final long JWT_EXPIRATION_IN_MS = 5400000;
 
 	private static final Long REFRESH_TOKEN_EXPIRATION_MSEC = 10800000L;
-
-	private static String getJwtSecret() {
-		try {
-			File jwtSecretFile = new File("jwt.secret");
-
-			if (jwtSecretFile.createNewFile()) {
-				Files.writeString(jwtSecretFile.toPath(), RandomStringUtils.random(32, 0, 0, true, true, null, new SecureRandom()));
-
-				LOG.debug("JWT Secret file created successfully in {}", jwtSecretFile.getAbsolutePath());
-			}
-
-			return Files.readString(jwtSecretFile.toPath());
-		} catch (IOException e) {
-            throw new JwtIudexException(e);
-        }
-    }
 
 	public String getUsername(String token) {
 		return Jwts.parserBuilder().setSigningKey(Keys.secretKeyFor(SignatureAlgorithm.HS256)).build()

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package es.urjc.etsii.grafo.iudex.security.jwt;
 
+import es.urjc.etsii.grafo.iudex.exceptions.JwtIudexException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,7 +21,7 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 	
-	private static final Logger LOG = LoggerFactory.getLogger(JwtRequestFilter.class);
+	private static final Logger LOG = LoggerFactory.getLogger(JwtTokenProvider.class);
 
 	private final String jwtSecret = getJwtSecret();
 
@@ -35,12 +36,12 @@ public class JwtTokenProvider {
 			if (jwtSecretFile.createNewFile()) {
 				Files.writeString(jwtSecretFile.toPath(), RandomStringUtils.random(32, 0, 0, true, true, null, new SecureRandom()));
 
-				LOG.debug("JWT Secret file created successfully in " + jwtSecretFile.getAbsolutePath());
+				LOG.debug("JWT Secret file created successfully in {}", jwtSecretFile.getAbsolutePath());
 			}
 
 			return Files.readString(jwtSecretFile.toPath());
 		} catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new JwtIudexException(e);
         }
     }
 

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
@@ -45,7 +45,8 @@ public class JwtTokenProvider {
     }
 
 	public String getUsername(String token) {
-		return Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token).getBody().getSubject();
+		return Jwts.parserBuilder().setSigningKey(Keys.secretKeyFor(SignatureAlgorithm.HS256)).build()
+				.parseClaimsJws(token).getBody().getSubject();
 	}
 
 	public String resolveToken(HttpServletRequest req) {
@@ -58,16 +59,11 @@ public class JwtTokenProvider {
 
 	public boolean validateToken(String token) {
 		try {
-			Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token);
+			Jwts.parserBuilder().setSigningKey(Keys.secretKeyFor(SignatureAlgorithm.HS256)).build()
+					.parseClaimsJws(token);
 			return true;
-		} catch (SignatureException ex) {
-			LOG.debug("Invalid JWT Signature");
-		} catch (MalformedJwtException ex) {
-			LOG.debug("Invalid JWT token");
-		} catch (ExpiredJwtException ex) {
-			LOG.debug("Expired JWT token");
-		} catch (UnsupportedJwtException ex) {
-			LOG.debug("Unsupported JWT exception");
+		} catch (JwtException ex) {
+			LOG.debug("Invalid JWT Token");
 		} catch (IllegalArgumentException ex) {
 			LOG.debug("JWT claims string is empty");
 		}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
@@ -1,13 +1,14 @@
 package es.urjc.etsii.grafo.iudex.security.jwt;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -92,7 +93,7 @@ public class JwtTokenProvider {
 		Long duration = now.getTime() + time;
 		Date expiryDate = new Date(now.getTime() + time);
 		String token = Jwts.builder().setClaims(claims).setSubject((userDetails.getUsername())).setIssuedAt(new Date())
-				.setExpiration(expiryDate).signWith(SignatureAlgorithm.HS256, jwtSecret).compact();
+				.setExpiration(expiryDate).signWith(Keys.secretKeyFor(SignatureAlgorithm.HS256)).compact();
 
 		return new Token(tokenType, token, duration,
 				LocalDateTime.ofInstant(expiryDate.toInstant(), ZoneId.systemDefault()));

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/UserService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/UserService.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 
-import javax.validation.constraints.Null;
+import jakarta.validation.constraints.Null;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/src/test/java/es/urjc/etsii/grafo/iudex/TheJudgeApplicationTests.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/TheJudgeApplicationTests.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.util.LinkedMultiValueMap;

--- a/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIAccessRoles.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIAccessRoles.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-public class TestAPIAccessRoles {
+class TestAPIAccessRoles {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,24 +35,24 @@ public class TestAPIAccessRoles {
 
     @Test
     @WithMockUser(username="admin",roles={"USER","ADMIN"})
-    public void adminShouldAccessAdminEndpoint() throws Exception {
+    void adminShouldAccessAdminEndpoint() throws Exception {
         mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isOk());
     }
 
     @Test
     @WithMockUser(username="judge",roles={"USER","JUDGE"})
-    public void judgeShouldBeDeniedAccessToAdminEndpoint() throws Exception {
+    void judgeShouldBeDeniedAccessToAdminEndpoint() throws Exception {
         mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isUnauthorized());
     }
 
     @Test
     @WithMockUser(username="user")
-    public void userShouldBeDeniedAccessToAdminEndpoint() throws Exception {
+    void userShouldBeDeniedAccessToAdminEndpoint() throws Exception {
         mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isUnauthorized());
     }
 
     @Test
-    public void unauthorizedShouldBeRedirectedOnAdminEndpoint() throws Exception {
+    void unauthorizedShouldBeRedirectedOnAdminEndpoint() throws Exception {
         mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().is3xxRedirection());
     }
 

--- a/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIAccessRoles.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIAccessRoles.java
@@ -42,13 +42,13 @@ public class TestAPIAccessRoles {
     @Test
     @WithMockUser(username="judge",roles={"USER","JUDGE"})
     public void judgeShouldBeDeniedAccessToAdminEndpoint() throws Exception {
-        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isForbidden());
+        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isUnauthorized());
     }
 
     @Test
     @WithMockUser(username="user")
     public void userShouldBeDeniedAccessToAdminEndpoint() throws Exception {
-        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isForbidden());
+        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIAccessRoles.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIAccessRoles.java
@@ -1,6 +1,5 @@
 package es.urjc.etsii.grafo.iudex.integrationtest.api_controllers;
 
-import es.urjc.etsii.grafo.iudex.configuration.TestConfigSecurity;
 import es.urjc.etsii.grafo.iudex.services.ResultService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,29 +7,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        classes = TestConfigSecurity.class
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 public class TestAPIAccessRoles {
 
     @Autowired
     private MockMvc mockMvc;
 
-    private String ADMIN_ONLY_URL = "/API/v1/result/";
+    private final String ADMIN_ONLY_URL = "/API/v1/result/";
 
     @MockBean
     private ResultService resultService;
@@ -41,30 +34,26 @@ public class TestAPIAccessRoles {
     }
 
     @Test
-    @WithUserDetails("admin")
+    @WithMockUser(username="admin",roles={"USER","ADMIN"})
     public void adminShouldAccessAdminEndpoint() throws Exception {
-        mockMvc.perform(get(ADMIN_ONLY_URL).with(jwt().authorities(new SimpleGrantedAuthority("ADMIN"))))
-                .andExpect(status().isOk());
+        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isOk());
     }
 
     @Test
-    @WithUserDetails("judge")
+    @WithMockUser(username="judge",roles={"USER","JUDGE"})
     public void judgeShouldBeDeniedAccessToAdminEndpoint() throws Exception {
-        mockMvc.perform(get(ADMIN_ONLY_URL).with(jwt().authorities(new SimpleGrantedAuthority("JUDGE"))))
-                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isForbidden());
     }
 
     @Test
-    @WithUserDetails("user")
+    @WithMockUser(username="user")
     public void userShouldBeDeniedAccessToAdminEndpoint() throws Exception {
-        mockMvc.perform(get(ADMIN_ONLY_URL).with(jwt().authorities(new SimpleGrantedAuthority("USER"))))
-                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().isForbidden());
     }
 
     @Test
     public void unauthorizedShouldBeRedirectedOnAdminEndpoint() throws Exception {
-        mockMvc.perform(get(ADMIN_ONLY_URL).with(anonymous()))
-                .andExpect(status().isTemporaryRedirect());
+        mockMvc.perform(get(ADMIN_ONLY_URL)).andExpect(status().is3xxRedirection());
     }
 
 }

--- a/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPISubmissionController.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPISubmissionController.java
@@ -1,6 +1,7 @@
 package es.urjc.etsii.grafo.iudex.integrationtest.api_controllers;
 
 import es.urjc.etsii.grafo.iudex.api.v1.APISubmissionController;
+import es.urjc.etsii.grafo.iudex.entities.*;
 import es.urjc.etsii.grafo.iudex.pojos.SubmissionStringResult;
 import es.urjc.etsii.grafo.iudex.security.jwt.JwtRequestFilter;
 import es.urjc.etsii.grafo.iudex.services.ContestProblemService;
@@ -8,7 +9,6 @@ import es.urjc.etsii.grafo.iudex.services.ContestService;
 import es.urjc.etsii.grafo.iudex.services.ProblemService;
 import es.urjc.etsii.grafo.iudex.services.SubmissionService;
 import es.urjc.etsii.grafo.iudex.utils.JSONConverter;
-import es.urjc.etsii.grafo.iudex.entities.*;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -120,7 +119,7 @@ class TestAPISubmissionController {
         String badProblem = "312";
         String goodContest = String.valueOf(contest.getId());
         String badContest = "654";
-        String url = "/API/v1/submissions/";
+        String url = "/API/v1/submissions";
 
         String salida = "";
         HttpStatus status = HttpStatus.NOT_FOUND;

--- a/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPITeamController.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPITeamController.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -103,7 +102,7 @@ class TestAPITeamController {
     void testAPICreateTeam() throws Exception {
         String badTeam = "";
         String goodTeam = team.getNombreEquipo();
-        String url = "/API/v1/team/";
+        String url = "/API/v1/team";
 
         TeamString ts = new TeamString();
         String salida = "";

--- a/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIUserController.java
+++ b/src/test/java/es/urjc/etsii/grafo/iudex/integrationtest/api_controllers/TestAPIUserController.java
@@ -19,8 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Optional;
 


### PR DESCRIPTION
Se ha actualizado SpringBoot a su versión 3 (#154) y se han arreglado partes de la aplicación que han quedado decrecadas y hacían que fuera inutilizable. 

Asímismo, como la librería javax ya no se utiliza para Spring, la dependencia [docker-java](https://github.com/docker-java/docker-java) recomendaba dejar de utilizar la librería de [Jersey](https://github.com/docker-java/docker-java/blob/main/docs/transports.md#jersey) como transporte, por lo que ha actualizado y ahora se utilizará [Apache HttpClient en su versión 5](https://github.com/docker-java/docker-java/blob/main/docs/transports.md#apache-httpclient-5).