### PR TITLE
Arreglo procesado de Tokens JWT

### DIFF
--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIAdminController.java
@@ -4,19 +4,23 @@ import es.urjc.etsii.grafo.iudex.entities.Result;
 import es.urjc.etsii.grafo.iudex.services.ResultService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 public class APIAdminController {
 
-    @Autowired
-    ResultService resultService;
+    final ResultService resultService;
+
+    public APIAdminController(ResultService resultService) {
+        this.resultService = resultService;
+    }
 
     @Operation( summary = "Get a full Result")
     @GetMapping("/API/v1/result/{resultId}")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIContestController.java
@@ -7,7 +7,6 @@ import es.urjc.etsii.grafo.iudex.pojos.TeamScore;
 import es.urjc.etsii.grafo.iudex.services.ContestService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -23,8 +22,11 @@ import java.util.Optional;
 @RequestMapping("/API/v1/")
 public class APIContestController {
 
-    @Autowired
-    ContestService contestService;
+    final ContestService contestService;
+
+    public APIContestController(ContestService contestService) {
+        this.contestService = contestService;
+    }
 
     @Operation( summary = "Return all contests")
     @GetMapping("contest")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APILanguageController.java
@@ -4,11 +4,12 @@ import es.urjc.etsii.grafo.iudex.entities.Language;
 import es.urjc.etsii.grafo.iudex.pojos.LanguageAPI;
 import es.urjc.etsii.grafo.iudex.services.LanguageService;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,8 +17,11 @@ import java.util.List;
 @RestController
 @RequestMapping("/API/v1/")
 public class APILanguageController {
-    @Autowired
-    private LanguageService languageService;
+    private final LanguageService languageService;
+
+    public APILanguageController(LanguageService languageService) {
+        this.languageService = languageService;
+    }
 
     @Operation( summary = "Return all languages")
     @GetMapping("language")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIOAuthController.java
@@ -2,20 +2,24 @@ package es.urjc.etsii.grafo.iudex.api.v1;
 
 import es.urjc.etsii.grafo.iudex.security.jwt.AuthResponse;
 import es.urjc.etsii.grafo.iudex.services.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/API/v1/oauth")
 public class APIOAuthController {
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
+
+    public APIOAuthController(UserService userService) {
+        this.userService = userService;
+    }
 
     @GetMapping("/login")
     @PreAuthorize("hasAuthority('OIDC_USER')")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIProblemController.java
@@ -24,8 +24,11 @@ import java.util.Optional;
 @RequestMapping("/API/v1/")
 public class APIProblemController {
 
-    @Autowired
-    ProblemService problemService;
+    final ProblemService problemService;
+
+    public APIProblemController(ProblemService problemService) {
+        this.problemService = problemService;
+    }
 
     //Get all problems in DB
     @Operation( summary = "Return All Problems")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APISubmissionController.java
@@ -12,7 +12,6 @@ import es.urjc.etsii.grafo.iudex.services.ProblemService;
 import es.urjc.etsii.grafo.iudex.services.SubmissionService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -29,14 +28,20 @@ import java.util.Optional;
 @RestController
 public class APISubmissionController {
 
-    @Autowired
-    SubmissionService submissionService;
-    @Autowired
-    ContestService contestService;
-    @Autowired
-    ProblemService problemService;
-    @Autowired
-    ContestProblemService contestProblemService;
+    final SubmissionService submissionService;
+    final ContestService contestService;
+    final ProblemService problemService;
+    final ContestProblemService contestProblemService;
+
+    public APISubmissionController(ContestProblemService contestProblemService,
+                                   ProblemService problemService,
+                                   ContestService contestService,
+                                   SubmissionService submissionService) {
+        this.contestProblemService = contestProblemService;
+        this.problemService = problemService;
+        this.contestService = contestService;
+        this.submissionService = submissionService;
+    }
 
     @Operation( summary = "Get List of submission given problem, contest or both at the same time")
     @GetMapping("/API/v1/submissions")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APITeamController.java
@@ -6,7 +6,6 @@ import es.urjc.etsii.grafo.iudex.pojos.TeamString;
 import es.urjc.etsii.grafo.iudex.services.UserAndTeamService;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,8 +17,11 @@ import java.util.Optional;
 
 @RestController
 public class APITeamController {
-    @Autowired
-    UserAndTeamService teamService;
+    final UserAndTeamService teamService;
+
+    public APITeamController(UserAndTeamService teamService) {
+        this.teamService = teamService;
+    }
 
     @Operation( summary = "Return all Teams")
     @GetMapping("/API/v1/team")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/api/v1/APIUserController.java
@@ -3,10 +3,12 @@ package es.urjc.etsii.grafo.iudex.api.v1;
 import es.urjc.etsii.grafo.iudex.entities.User;
 import es.urjc.etsii.grafo.iudex.services.UserAndTeamService;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,8 +16,11 @@ import java.util.Optional;
 @RestController
 public class APIUserController {
 
-    @Autowired
-    UserAndTeamService userAndTeamService;
+    final UserAndTeamService userAndTeamService;
+
+    public APIUserController(UserAndTeamService userAndTeamService) {
+        this.userAndTeamService = userAndTeamService;
+    }
 
     @Operation( summary = "Add a specific role to an existing user")
     @PostMapping("/API/v1/user/{id}/role/{role}")

--- a/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultExecutionReceiver.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultExecutionReceiver.java
@@ -5,7 +5,6 @@ import es.urjc.etsii.grafo.iudex.exceptions.DockerExecutionException;
 import es.urjc.etsii.grafo.iudex.services.ResultHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -13,14 +12,18 @@ import java.io.IOException;
 //Clase que se encarga de recibir un result y mandarlo al servicio docker.
 @Service
 public class RabbitResultExecutionReceiver {
-    @Autowired
-    private ResultHandler resultHandler;
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
+    private final ResultHandler resultHandler;
+    private final RabbitTemplate rabbitTemplate;
 
-    @Autowired
-    private RabbitResultReviserSender rabbitResultReviserSender;
+    private final RabbitResultReviserSender rabbitResultReviserSender;
 
+    public RabbitResultExecutionReceiver(RabbitResultReviserSender rabbitResultReviserSender,
+                                         RabbitTemplate rabbitTemplate,
+                                         ResultHandler resultHandler) {
+        this.rabbitResultReviserSender = rabbitResultReviserSender;
+        this.rabbitTemplate = rabbitTemplate;
+        this.resultHandler = resultHandler;
+    }
 
     //LIstener que recibe el objeto resultado desde la cola
     @RabbitListener(queues = ConfigureRabbitMq.QUEUE_NAME)

--- a/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultExecutionSender.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultExecutionSender.java
@@ -3,15 +3,17 @@ package es.urjc.etsii.grafo.iudex.rabbitmq;
 
 import es.urjc.etsii.grafo.iudex.entities.Result;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 //Clase que se encarga de enviar un result a la cola
 @Service
 public class RabbitResultExecutionSender {
 
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
+    private final RabbitTemplate rabbitTemplate;
+
+    public RabbitResultExecutionSender(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
 
 
     public void sendMessage(Result res) {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultRevieserReceiver.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultRevieserReceiver.java
@@ -7,7 +7,6 @@ import es.urjc.etsii.grafo.iudex.repositories.SubmissionRepository;
 import es.urjc.etsii.grafo.iudex.services.ResultReviser;
 import es.urjc.etsii.grafo.iudex.services.SubmissionReviserService;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,13 +15,17 @@ import java.util.Optional;
 //Clase que se encarga de recibir el result
 @Service
 public class RabbitResultRevieserReceiver {
-    @Autowired
     private ResultRepository resultRepository;
-    @Autowired
     private SubmissionRepository submissionRepository;
-    @Autowired
-    private SubmissionReviserService submissionReviserService;
+    private final SubmissionReviserService submissionReviserService;
 
+    public RabbitResultRevieserReceiver(SubmissionReviserService submissionReviserService,
+                                        SubmissionRepository submissionRepository,
+                                        ResultRepository resultRepository) {
+        this.submissionReviserService = submissionReviserService;
+        this.submissionRepository = submissionRepository;
+        this.resultRepository = resultRepository;
+    }
 
     @RabbitListener(queues = ConfigureRabbitMq.QUEUE_NAME2)
     @Transactional

--- a/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultReviserSender.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/rabbitmq/RabbitResultReviserSender.java
@@ -2,15 +2,17 @@ package es.urjc.etsii.grafo.iudex.rabbitmq;
 
 import es.urjc.etsii.grafo.iudex.entities.Result;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 //Clase que envia los datos a la cola
 @Service
 public class RabbitResultReviserSender {
 
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
+    private final RabbitTemplate rabbitTemplate;
+
+    public RabbitResultReviserSender(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
 
 
     public void sendMenssage(Result res) {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/ConfigSecurity.java
@@ -1,5 +1,7 @@
 package es.urjc.etsii.grafo.iudex.security;
 
+import es.urjc.etsii.grafo.iudex.security.jwt.JwtRequestFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -8,11 +10,15 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(jsr250Enabled=true)
 class ConfigSecurity {
+
+    @Autowired
+    private JwtRequestFilter jwtRequestFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -22,6 +28,9 @@ class ConfigSecurity {
 
         // Disable CORS and CSRF protection
         http.cors(AbstractHttpConfigurer::disable).csrf(AbstractHttpConfigurer::disable);
+
+        // Add JWT Token filter
+        http.addFilterBefore(jwtRequestFilter, BasicAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtRequestFilter.java
@@ -1,8 +1,11 @@
 package es.urjc.etsii.grafo.iudex.security.jwt;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,10 +14,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component
@@ -22,11 +21,14 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(JwtRequestFilter.class);
 
-	@Autowired
-	private UserDetailsServiceImp userDetailsService;
+	private final UserDetailsServiceImp userDetailsService;
 
-	@Autowired
-	private JwtTokenProvider jwtTokenProvider;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public JwtRequestFilter(UserDetailsServiceImp userDetailsService, JwtTokenProvider jwtTokenProvider) {
+		this.userDetailsService = userDetailsService;
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -24,8 +25,10 @@ public class JwtTokenProvider {
 
 	private static final Long REFRESH_TOKEN_EXPIRATION_MSEC = 10800000L;
 
+	private static final Key jwtSecret = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
 	public String getUsername(String token) {
-		return Jwts.parserBuilder().setSigningKey(Keys.secretKeyFor(SignatureAlgorithm.HS256)).build()
+		return Jwts.parserBuilder().setSigningKey(jwtSecret).build()
 				.parseClaimsJws(token).getBody().getSubject();
 	}
 
@@ -39,7 +42,7 @@ public class JwtTokenProvider {
 
 	public boolean validateToken(String token) {
 		try {
-			Jwts.parserBuilder().setSigningKey(Keys.secretKeyFor(SignatureAlgorithm.HS256)).build()
+			Jwts.parserBuilder().setSigningKey(jwtSecret).build()
 					.parseClaimsJws(token);
 			return true;
 		} catch (JwtException ex) {
@@ -69,7 +72,7 @@ public class JwtTokenProvider {
 		Long duration = now.getTime() + time;
 		Date expiryDate = new Date(now.getTime() + time);
 		String token = Jwts.builder().setClaims(claims).setSubject((userDetails.getUsername())).setIssuedAt(new Date())
-				.setExpiration(expiryDate).signWith(Keys.secretKeyFor(SignatureAlgorithm.HS256)).compact();
+				.setExpiration(expiryDate).signWith(jwtSecret).compact();
 
 		return new Token(tokenType, token, duration,
 				LocalDateTime.ofInstant(expiryDate.toInstant(), ZoneId.systemDefault()));

--- a/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/UserDetailsServiceImp.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/security/jwt/UserDetailsServiceImp.java
@@ -2,7 +2,6 @@ package es.urjc.etsii.grafo.iudex.security.jwt;
 
 import es.urjc.etsii.grafo.iudex.entities.User;
 import es.urjc.etsii.grafo.iudex.repositories.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,8 +15,11 @@ import java.util.List;
 @Service
 public class UserDetailsServiceImp implements UserDetailsService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImp(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/ContestProblemService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/ContestProblemService.java
@@ -4,7 +4,6 @@ import es.urjc.etsii.grafo.iudex.entities.Contest;
 import es.urjc.etsii.grafo.iudex.entities.ContestProblem;
 import es.urjc.etsii.grafo.iudex.entities.Problem;
 import es.urjc.etsii.grafo.iudex.repositories.ContestProblemRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -12,8 +11,11 @@ import java.util.Optional;
 @Service
 public class ContestProblemService {
 
-    @Autowired
-    private ContestProblemRepository contestProblemRepository;
+    private final ContestProblemRepository contestProblemRepository;
+
+    public ContestProblemService(ContestProblemRepository contestProblemRepository) {
+        this.contestProblemRepository = contestProblemRepository;
+    }
 
     public void save(ContestProblem contestProblem) {
         contestProblemRepository.save(contestProblem);

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/ContestService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/ContestService.java
@@ -13,7 +13,6 @@ import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import es.urjc.etsii.grafo.iudex.utils.TeamScoreComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,22 +27,32 @@ import java.util.stream.Collectors;
 public class ContestService {
     private static final Logger logger = LoggerFactory.getLogger(ContestService.class);
 
-    @Autowired
-    private ContestRepository contestRepository;
-    @Autowired
-    private ContestProblemRepository contestProblemRepository;
-    @Autowired
-    private TeamRepository teamRepository;
-    @Autowired
-    private ContestTeamRespository contestTeamRespository;
-    @Autowired
-    private ProblemService problemService;
-    @Autowired
-    private UserAndTeamService teamService;
-    @Autowired
-    private LanguageService languageService;
-    @Autowired
-    private ContestProblemService contestProblemService;
+    private final ContestRepository contestRepository;
+    private final ContestProblemRepository contestProblemRepository;
+    private final TeamRepository teamRepository;
+    private final ContestTeamRespository contestTeamRespository;
+    private final ProblemService problemService;
+    private final UserAndTeamService teamService;
+    private final LanguageService languageService;
+    private final ContestProblemService contestProblemService;
+
+    public ContestService(ContestProblemService contestProblemService,
+                          LanguageService languageService,
+                          UserAndTeamService teamService,
+                          ProblemService problemService,
+                          ContestTeamRespository contestTeamRespository,
+                          TeamRepository teamRepository,
+                          ContestProblemRepository contestProblemRepository,
+                          ContestRepository contestRepository) {
+        this.contestProblemService = contestProblemService;
+        this.languageService = languageService;
+        this.teamService = teamService;
+        this.problemService = problemService;
+        this.contestTeamRespository = contestTeamRespository;
+        this.teamRepository = teamRepository;
+        this.contestProblemRepository = contestProblemRepository;
+        this.contestRepository = contestRepository;
+    }
 
     public ContestString creaContest(String nameContest, String teamId, Optional<String> description, long startTimestamp, long endTimestamp) {
         logger.debug("Build contest {}", nameContest);

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/ContestTeamService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/ContestTeamService.java
@@ -2,14 +2,16 @@ package es.urjc.etsii.grafo.iudex.services;
 
 import es.urjc.etsii.grafo.iudex.entities.ContestTeams;
 import es.urjc.etsii.grafo.iudex.repositories.ContestTeamRespository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ContestTeamService {
 
-    @Autowired
-    private ContestTeamRespository contestTeamRespository;
+    private final ContestTeamRespository contestTeamRespository;
+
+    public ContestTeamService(ContestTeamRespository contestTeamRespository) {
+        this.contestTeamRespository = contestTeamRespository;
+    }
 
     public void save(ContestTeams contestTeams) {
         contestTeamRespository.save(contestTeams);

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/LanguageService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/LanguageService.java
@@ -2,7 +2,6 @@ package es.urjc.etsii.grafo.iudex.services;
 
 import es.urjc.etsii.grafo.iudex.entities.Language;
 import es.urjc.etsii.grafo.iudex.repositories.LanguageRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,8 +9,11 @@ import java.util.Optional;
 
 @Service
 public class LanguageService {
-    @Autowired
-    private LanguageRepository languageRepository;
+    private final LanguageRepository languageRepository;
+
+    public LanguageService(LanguageRepository languageRepository) {
+        this.languageRepository = languageRepository;
+    }
 
     public Optional<Language> getLanguage(String id) {
         return languageRepository.findLanguageById(Long.parseLong(id));

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/OnStartRunner.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/OnStartRunner.java
@@ -3,7 +3,6 @@ package es.urjc.etsii.grafo.iudex.services;
 import es.urjc.etsii.grafo.iudex.entities.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -19,16 +18,22 @@ import java.util.TimeZone;
 public class OnStartRunner implements ApplicationRunner {
     private static final Logger logger = LoggerFactory.getLogger(OnStartRunner.class);
 
-    @Autowired
-    private ContestService contestService;
-    @Autowired
-    private UserAndTeamService userAndTeamService;
+    private final ContestService contestService;
+    private final UserAndTeamService userAndTeamService;
 
-    @Autowired
-    private LanguageService languageService;
+    private final LanguageService languageService;
 
-    @Autowired
-    private ResultHandler resultHandler;
+    private final ResultHandler resultHandler;
+
+    public OnStartRunner(ResultHandler resultHandler,
+                         LanguageService languageService,
+                         UserAndTeamService userAndTeamService,
+                         ContestService contestService) {
+        this.resultHandler = resultHandler;
+        this.languageService = languageService;
+        this.userAndTeamService = userAndTeamService;
+        this.contestService = contestService;
+    }
 
     @Override
     public void run(ApplicationArguments args) throws Exception {

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/ProblemValidatorService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/ProblemValidatorService.java
@@ -9,7 +9,6 @@ import es.urjc.etsii.grafo.iudex.repositories.ProblemRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -23,13 +22,18 @@ import java.util.Optional;
 public class ProblemValidatorService {
     private static final Logger logger = LoggerFactory.getLogger(ProblemValidatorService.class);
 
-    @Autowired
-    private ProblemRepository problemRepository;
+    private final ProblemRepository problemRepository;
 
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
-    @Autowired
-    private RabbitResultExecutionSender sender;
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitResultExecutionSender sender;
+
+    public ProblemValidatorService(RabbitResultExecutionSender sender,
+                                   RabbitTemplate rabbitTemplate,
+                                   ProblemRepository problemRepository) {
+        this.sender = sender;
+        this.rabbitTemplate = rabbitTemplate;
+        this.problemRepository = problemRepository;
+    }
 
     public void validateProblem(Problem problemA) {
         Optional<Problem> problemOptional = problemRepository.findProblemById(problemA.getId());

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/ResultService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/ResultService.java
@@ -2,15 +2,17 @@ package es.urjc.etsii.grafo.iudex.services;
 
 import es.urjc.etsii.grafo.iudex.entities.Result;
 import es.urjc.etsii.grafo.iudex.repositories.ResultRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
 public class ResultService {
-    @Autowired
-    private ResultRepository resultRepository;
+    private final ResultRepository resultRepository;
+
+    public ResultService(ResultRepository resultRepository) {
+        this.resultRepository = resultRepository;
+    }
 
     public Result getResult(String resultId) {
         return resultRepository.findResultById(Long.parseLong(resultId)).orElseThrow();

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/SubmissionProblemValidatorService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/SubmissionProblemValidatorService.java
@@ -3,13 +3,15 @@ package es.urjc.etsii.grafo.iudex.services;
 import es.urjc.etsii.grafo.iudex.entities.Problem;
 import es.urjc.etsii.grafo.iudex.entities.SubmissionProblemValidator;
 import es.urjc.etsii.grafo.iudex.pojos.SubmissionStringResult;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SubmissionProblemValidatorService {
-    @Autowired
-    private SubmissionService submissionService;
+    private final SubmissionService submissionService;
+
+    public SubmissionProblemValidatorService(SubmissionService submissionService) {
+        this.submissionService = submissionService;
+    }
 
     public SubmissionProblemValidator createSubmissionNoExecute(String codigo, Problem problema, String lenguaje, String fileName, String expectedResult, String idEquipo, String contestId) {
         SubmissionProblemValidator submissionProblemValidator = new SubmissionProblemValidator();

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/SubmissionReviserService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/SubmissionReviserService.java
@@ -11,7 +11,6 @@ import es.urjc.etsii.grafo.iudex.repositories.SubmissionProblemValidatorReposito
 import es.urjc.etsii.grafo.iudex.repositories.SubmissionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,19 +21,26 @@ import java.util.Optional;
 public class SubmissionReviserService {
     private static final Logger logger = LoggerFactory.getLogger(SubmissionReviserService.class);
 
-    @Autowired
-    private SubmissionRepository submissionRepository;
-    @Autowired
-    private SubmissionProblemValidatorRepository submissionProblemValidatorRepository;
+    private final SubmissionRepository submissionRepository;
+    private final SubmissionProblemValidatorRepository submissionProblemValidatorRepository;
 
-    @Autowired
-    private ProblemValidatorService problemValidatorService;
+    private final ProblemValidatorService problemValidatorService;
 
-    @Autowired
-    private IudexSpecificContestSubmissionEventPublisher iudexSpecificContestSubmissionEventPublisher;
+    private final IudexSpecificContestSubmissionEventPublisher iudexSpecificContestSubmissionEventPublisher;
 
-    @Autowired
-    private IudexSpecificContestTeamSubmissionEventPublisher iudexSpecificContestTeamSubmissionEventPublisher;
+    private final IudexSpecificContestTeamSubmissionEventPublisher iudexSpecificContestTeamSubmissionEventPublisher;
+
+    public SubmissionReviserService(IudexSpecificContestTeamSubmissionEventPublisher iudexSpecificContestTeamSubmissionEventPublisher,
+                                    IudexSpecificContestSubmissionEventPublisher iudexSpecificContestSubmissionEventPublisher,
+                                    ProblemValidatorService problemValidatorService,
+                                    SubmissionProblemValidatorRepository submissionProblemValidatorRepository,
+                                    SubmissionRepository submissionRepository) {
+        this.iudexSpecificContestTeamSubmissionEventPublisher = iudexSpecificContestTeamSubmissionEventPublisher;
+        this.iudexSpecificContestSubmissionEventPublisher = iudexSpecificContestSubmissionEventPublisher;
+        this.problemValidatorService = problemValidatorService;
+        this.submissionProblemValidatorRepository = submissionProblemValidatorRepository;
+        this.submissionRepository = submissionRepository;
+    }
 
     @Transactional
     //Metodo que revisa si una submission ha sido aceptada y si no, indica el primero de los errores que ha dado

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/SubmissionService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/SubmissionService.java
@@ -1,15 +1,14 @@
 package es.urjc.etsii.grafo.iudex.services;
 
+import es.urjc.etsii.grafo.iudex.entities.*;
 import es.urjc.etsii.grafo.iudex.pojos.SubmissionStringResult;
 import es.urjc.etsii.grafo.iudex.rabbitmq.RabbitResultExecutionSender;
-import es.urjc.etsii.grafo.iudex.entities.*;
 import es.urjc.etsii.grafo.iudex.repositories.*;
 import es.urjc.etsii.grafo.iudex.utils.Sanitizer;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -28,25 +27,36 @@ import java.util.Set;
 public class SubmissionService {
     private static final Logger logger = LoggerFactory.getLogger(SubmissionService.class);
 
-    @Autowired
-    private ContestRepository contestRepository;
-    @Autowired
-    private ContestProblemRepository contestProblemRepository;
-    @Autowired
-    private ProblemRepository problemRepository;
-    @Autowired
-    private TeamRepository teamRepository;
-    @Autowired
-    private LanguageRepository languageRepository;
-    @Autowired
-    private SubmissionRepository submissionRepository;
-    @Autowired
-    private ResultRepository resultRepository;
+    private final ContestRepository contestRepository;
+    private final ContestProblemRepository contestProblemRepository;
+    private final ProblemRepository problemRepository;
+    private final TeamRepository teamRepository;
+    private final LanguageRepository languageRepository;
+    private final SubmissionRepository submissionRepository;
+    private final ResultRepository resultRepository;
 
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
-    @Autowired
-    private RabbitResultExecutionSender sender;
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitResultExecutionSender sender;
+
+    public SubmissionService(RabbitResultExecutionSender sender,
+                             RabbitTemplate rabbitTemplate,
+                             ResultRepository resultRepository,
+                             SubmissionRepository submissionRepository,
+                             LanguageRepository languageRepository,
+                             TeamRepository teamRepository,
+                             ProblemRepository problemRepository,
+                             ContestProblemRepository contestProblemRepository,
+                             ContestRepository contestRepository) {
+        this.sender = sender;
+        this.rabbitTemplate = rabbitTemplate;
+        this.resultRepository = resultRepository;
+        this.submissionRepository = submissionRepository;
+        this.languageRepository = languageRepository;
+        this.teamRepository = teamRepository;
+        this.problemRepository = problemRepository;
+        this.contestProblemRepository = contestProblemRepository;
+        this.contestRepository = contestRepository;
+    }
 
     public SubmissionStringResult creaYejecutaSubmission(MultipartFile codigoFile, String problem, String lenguaje, String idContest, String idEquipo) throws IOException {
         String codigo = new String(codigoFile.getBytes());

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/UserAndTeamService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/UserAndTeamService.java
@@ -255,11 +255,12 @@ public class UserAndTeamService {
             return salida;
         }
 
+        userTeamRespository.save(teamUser);
         team.getParticipantes().add(teamUser);
         teamRepository.save(team);
 
         salida.setSalida("OK");
-        salida.setTeam(team);
+        salida.setTeam(teamRepository.findTeamById(team.getId()).orElseThrow());
         logger.debug("Finish add user {} to team {}", userId, teamId);
         return salida;
     }

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/UserService.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/UserService.java
@@ -6,7 +6,6 @@ import es.urjc.etsii.grafo.iudex.repositories.UserRepository;
 import es.urjc.etsii.grafo.iudex.security.jwt.AuthResponse;
 import es.urjc.etsii.grafo.iudex.security.jwt.JwtTokenProvider;
 import es.urjc.etsii.grafo.iudex.security.jwt.UserDetailsServiceImp;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -18,14 +17,17 @@ import java.util.Optional;
 @Service
 public class UserService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
-    @Autowired
-    private UserDetailsServiceImp userDetailsServiceImp;
+    private final UserDetailsServiceImp userDetailsServiceImp;
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public UserService(UserRepository userRepository, UserDetailsServiceImp userDetailsServiceImp, JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.userDetailsServiceImp = userDetailsServiceImp;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
 
     public User getUserFromOAuthPrincipal(OAuth2User oAuth2User) {
         Optional<User> user = userRepository.findUserByEmail(oAuth2User.getAttribute("email"));


### PR DESCRIPTION
Tras la actualización a Spring 3, los tokens dejaban de ser procesados ya que la aplicación no pasaba por el filtro JwtRequestFilter implementado. Por este motivo, se ha añadido el filtro a la configuración de la aplicación y ahora se validan correctamente en cada petición. 

Asímismo, se ha observado un error en el punto de servicio para añadir usuario a equipos, por lo que se ha dejado su arreglo en esta rama.