### PR TITLE
Aplicación del patrón Simple Factory para las clases DockerContainer

### DIFF
--- a/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainer.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainer.java
@@ -1,12 +1,11 @@
 package es.urjc.etsii.grafo.iudex.docker;
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.model.HostConfig;
 import es.urjc.etsii.grafo.iudex.entities.Result;
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.exception.InternalServerErrorException;
-import es.urjc.etsii.grafo.iudex.exceptions.UnacceptedLanguageException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -18,49 +17,44 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-public class DockerContainer {
+public abstract class DockerContainer {
     private static final Logger logger = LoggerFactory.getLogger(DockerContainer.class);
-    private static DockerClient dockerClient = null;
+    protected static DockerClient dockerClient = null;
 
-    private final Set<String> acceptedLanguages = Set.of("c", "cpp", "java", "sql", "python3");
-
-    public DockerContainer(DockerClient dockerClient) {
+    protected DockerContainer(DockerClient dockerClient) {
         DockerContainer.dockerClient = dockerClient;
     }
 
     public Result ejecutar(Result result, String defaultMemoryLimit, String defaultTimeout, String defaultCPU, String imagenId) throws IOException, InterruptedException {
         String language = result.getLanguage().getNombreLenguaje();
-        if (!acceptedLanguages.contains(language)) { throw new UnacceptedLanguageException(""); }
 
         logger.debug("Building {} container for image {}", language, imagenId);
 
-        String nombreClase = (language.equals("java")) ? this.getJavaClassName(result) : result.getFileName();
-        String nombreDocker = "a" + result.getId() + "_" + java.time.LocalDateTime.now();
+        String nombreClase = this.getClassName(result);
+        String nombreDocker = "iudex_" + result.getId() + "_" + java.time.LocalDateTime.now();
         nombreDocker = nombreDocker.replace(":", "");
 
         //Creamos el contendor
         HostConfig hostConfig = new HostConfig().withMemory(Long.parseLong(defaultMemoryLimit)).withCpusetCpus(defaultCPU);
-        String[] env = this.getEnv(result, language, defaultTimeout);
         try (CreateContainerCmd createContainerCmd = dockerClient.createContainerCmd(imagenId)
                 .withNetworkDisabled(true)
-                .withEnv(env)
+                .withEnv(this.getEnv(result, defaultTimeout))
                 .withHostConfig(hostConfig)
                 .withName(nombreDocker)) {
             CreateContainerResponse container = createContainerCmd.exec();
             logger.debug("DOCKER {}: Running container for result {} with timeout {} and memory limit {}", language, result.getId(), result.getMaxTimeout(), result.getMaxMemory());
 
-            copyInputDataToContainer(container, result, nombreClase + "." + this.getFileExtension(language));
+            copyInputDataToContainer(container, result, nombreClase + "." + this.getFileExtension());
 
             dockerClient.startContainerCmd(container.getId()).exec();
 
             waitUntilContainerStopped(container);
-            setReturnedValuesFromContainer(container, result, language);
+            setReturnedValuesFromContainer(container, result);
 
             dockerClient.removeContainerCmd(container.getId()).withRemoveVolumes(true).exec();
         }
@@ -69,7 +63,13 @@ public class DockerContainer {
         return result;
     }
 
-    private void copyInputDataToContainer(CreateContainerResponse container, Result result, String codeFileName) throws IOException {
+    protected abstract String getClassName(Result result);
+
+    protected abstract String getFileExtension();
+
+    protected abstract String getFileName1(Result result);
+
+    protected void copyInputDataToContainer(CreateContainerResponse container, Result result, String codeFileName) throws IOException {
         //Copiamos el codigo
         copiarArchivoAContenedor(container.getId(), codeFileName, result.getCodigo(), "/root");
 
@@ -77,7 +77,7 @@ public class DockerContainer {
         copiarArchivoAContenedor(container.getId(), "entrada.in", result.getEntrada(), "/root");
     }
 
-    protected void setReturnedValuesFromContainer(CreateContainerResponse container, Result result, String language) throws IOException {
+    protected void setReturnedValuesFromContainer(CreateContainerResponse container, Result result) throws IOException {
         //Buscamos la salida Estandar
         String salidaEstandar = copiarArchivoDeContenedor(container.getId(), "root/salidaEstandar.ans");
         result.setSalidaEstandar(salidaEstandar);
@@ -93,10 +93,10 @@ public class DockerContainer {
         String time = copiarArchivoDeContenedor(container.getId(), "root/time.txt");
         result.setSalidaTime(time);
 
-        this.setSignals(result, container, language);
+        this.setSignals(result, container);
     }
 
-    private void waitUntilContainerStopped(CreateContainerResponse container) throws InterruptedException {
+    protected void waitUntilContainerStopped(CreateContainerResponse container) throws InterruptedException {
         boolean isRunning;
         do {
             Thread.sleep(200);
@@ -104,73 +104,29 @@ public class DockerContainer {
         } while (isRunning);  //Mientras esta corriendo se hace el do
     }
 
-    private String getFileExtension(String language) {
-        return switch (language) {
-            case "sql" -> "sql";
-            case "java" -> "java";
-            case "c" -> "c";
-            case "cpp" -> "cpp";
-            case "python3" -> "py";
-            default -> throw new UnacceptedLanguageException("");
-        };
-    }
-
-    private String[] getEnv(Result result, String language, String defaultTimeout) {
-        String timeout;
-        if (result.getMaxTimeout() != null) { timeout = result.getMaxTimeout(); }
-        else { timeout = defaultTimeout; }
-
+    protected String[] getEnv(Result result, String defaultTimeout) {
         List<String> env = new ArrayList<>();
-        env.add("EXECUTION_TIMEOUT=" + timeout);
-        env.add("FILENAME2=" + getFileName2(result, getFileExtension(language)));
 
-        if (!language.equals("py")) { env.add("FILENAME1=" + getFileName1(result, language)); }
-
-        if (language.equals("java")) { env.add("MEMORYLIMIT=" + "-Xmx" + result.getMaxMemory() + "m"); }
+        env.add("EXECUTION_TIMEOUT=" + getTimeoutEnv(result, defaultTimeout));
+        env.add("FILENAME2=" + getFileName2(result, getFileExtension()));
+        env.add("FILENAME1=" + getFileName1(result));
 
         return env.toArray(new String[0]);
     }
 
-    private String getFileName1(Result result, String language) {
-        return switch (language) {
-            case "sql" -> "entrada.in";
-            case "java" -> getJavaClassName(result);
-            case "python3", "cpp", "c" -> result.getFileName();
-            default -> throw new UnacceptedLanguageException("");
-        };
-    }
-
-    private String getFileName2(Result result, String fileExtension) {
-        if (fileExtension.equals("java")) { return this.getJavaClassName(result); }
-        else { return result.getFileName() + "." + fileExtension; }
-    }
-
-    private String getJavaClassName(Result result) {
-        Matcher publicClassMatcher = Pattern.compile("public\\s+class\\s+([a-zA-Z_$][a-zA-Z_$0-9]*)")
-                                       .matcher(result.getCodigo());
-        Matcher privateClassMatcher = Pattern.compile("class\\s+([a-zA-Z_$][a-zA-Z_$0-9]*)")
-                                        .matcher(result.getCodigo());
-
-        if (publicClassMatcher.find()) { return publicClassMatcher.group(1); }
-        else if (privateClassMatcher.find()) { return privateClassMatcher.group(1); }
-
-        return "";
-    }
-
-    private void setSignals(Result result, CreateContainerResponse container, String language) throws IOException {
-        if (language.equals("python3")) {
-            String signal = copiarArchivoDeContenedor(container.getId(), "root/signal.txt");
-            result.setSignalEjecutor(signal);
+    protected String getTimeoutEnv(Result result, String defaultTimeout) {
+        if (result.getMaxTimeout() != null) {
+            return result.getMaxTimeout();
         } else {
-            String signalEjecutor = copiarArchivoDeContenedor(container.getId(), "root/signalEjecutor.txt");
-            result.setSignalEjecutor(signalEjecutor);
-
-            String signalCompilador = copiarArchivoDeContenedor(container.getId(), "root/signalCompilador.txt");
-            result.setSignalCompilador(signalCompilador);
+            return defaultTimeout;
         }
     }
 
-    static void copiarArchivoAContenedor(String contAux, String nombre, String contenido, String pathDestino) throws IOException {
+    protected abstract String getFileName2(Result result, String fileExtension);
+
+    protected abstract void setSignals(Result result, CreateContainerResponse container) throws IOException;
+
+    protected static void copiarArchivoAContenedor(String contAux, String nombre, String contenido, String pathDestino) throws IOException {
         dockerClient.copyArchiveToContainerCmd(contAux).withTarInputStream(convertStringtoInputStream(nombre, contenido)).withRemotePath(pathDestino).exec();
     }
 
@@ -192,7 +148,7 @@ public class DockerContainer {
     }
 
     //Sacado de aqui https://stackoverflow.com/questions/25325442/wait-x-seconds-or-until-a-condition-becomes-true/25325830#comment85873450_25325830
-    static void waitUntil(BooleanSupplier condition, long timeoutms) throws TimeoutException {
+    protected static void waitUntil(BooleanSupplier condition, long timeoutms) throws TimeoutException {
         long start = System.currentTimeMillis();
         while (!condition.getAsBoolean()) {
             if (System.currentTimeMillis() - start > timeoutms) {
@@ -202,7 +158,7 @@ public class DockerContainer {
     }
 
     //sacado de aqui https://github.com/docker-java/docker-java/issues/991
-    String copiarArchivoDeContenedor(String contAux, String pathOrigen) throws IOException {
+    protected String copiarArchivoDeContenedor(String contAux, String pathOrigen) throws IOException {
         try {
             InputStream isSalida = dockerClient.copyArchiveFromContainerCmd(contAux, pathOrigen).exec();  //Obtenemos el InputStream del contenedor
             TarArchiveInputStream tarArchivo = new TarArchiveInputStream(isSalida);                     //Obtenemos el tar del IS

--- a/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerC.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerC.java
@@ -1,0 +1,47 @@
+package es.urjc.etsii.grafo.iudex.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import es.urjc.etsii.grafo.iudex.entities.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DockerContainerC extends DockerContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(DockerContainerC.class);
+
+    public DockerContainerC(DockerClient dockerClient) {
+        super(dockerClient);
+    }
+
+    @Override
+    protected String getClassName(Result result) {
+        return result.getFileName();
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return "c";
+    }
+
+    @Override
+    protected String getFileName1(Result result) {
+        return result.getFileName();
+    }
+
+    @Override
+    protected String getFileName2(Result result, String fileExtension) {
+        return result.getFileName() + "." + fileExtension;
+    }
+
+    @Override
+    protected void setSignals(Result result, CreateContainerResponse container) throws IOException {
+        String signalEjecutor = copiarArchivoDeContenedor(container.getId(), "root/signalEjecutor.txt");
+        result.setSignalEjecutor(signalEjecutor);
+
+        String signalCompilador = copiarArchivoDeContenedor(container.getId(), "root/signalCompilador.txt");
+        result.setSignalCompilador(signalCompilador);
+    }
+}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerCpp.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerCpp.java
@@ -1,0 +1,47 @@
+package es.urjc.etsii.grafo.iudex.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import es.urjc.etsii.grafo.iudex.entities.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DockerContainerCpp extends DockerContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(DockerContainerCpp.class);
+
+    public DockerContainerCpp(DockerClient dockerClient) {
+        super(dockerClient);
+    }
+
+    @Override
+    protected String getClassName(Result result) {
+        return result.getFileName();
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return "cpp";
+    }
+
+    @Override
+    protected String getFileName1(Result result) {
+        return result.getFileName();
+    }
+
+    @Override
+    protected String getFileName2(Result result, String fileExtension) {
+        return result.getFileName() + "." + fileExtension;
+    }
+
+    @Override
+    protected void setSignals(Result result, CreateContainerResponse container) throws IOException {
+        String signalEjecutor = copiarArchivoDeContenedor(container.getId(), "root/signalEjecutor.txt");
+        result.setSignalEjecutor(signalEjecutor);
+
+        String signalCompilador = copiarArchivoDeContenedor(container.getId(), "root/signalCompilador.txt");
+        result.setSignalCompilador(signalCompilador);
+    }
+}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerFactory.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerFactory.java
@@ -1,0 +1,23 @@
+package es.urjc.etsii.grafo.iudex.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import es.urjc.etsii.grafo.iudex.entities.Result;
+
+public class DockerContainerFactory {
+
+    public static DockerContainer createDockerContainerForLanguage(String language, DockerClient dockerClient) {
+        return switch (language) {
+            case "java" -> new DockerContainerJava(dockerClient);
+            case "python3" -> new DockerContainerPython(dockerClient);
+            case "cpp" -> new DockerContainerCpp(dockerClient);
+            case "c" -> new DockerContainerC(dockerClient);
+            case "sql" -> new DockerContainerMySQL(dockerClient);
+            default -> throw new IllegalArgumentException("Language not supported: " + language);
+        };
+    }
+
+    public static DockerContainer createDockerContainerForResult(Result result, DockerClient dockerClient) {
+        return createDockerContainerForLanguage(result.getLanguage().getNombreLenguaje(), dockerClient);
+    }
+
+}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerJava.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerJava.java
@@ -1,0 +1,75 @@
+package es.urjc.etsii.grafo.iudex.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import es.urjc.etsii.grafo.iudex.entities.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DockerContainerJava extends DockerContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(DockerContainerJava.class);
+
+    public DockerContainerJava(DockerClient dockerClient) {
+        super(dockerClient);
+    }
+
+    @Override
+    protected String getClassName(Result result) {
+        return this.getJavaClassName(result);
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return "java";
+    }
+
+    @Override
+    protected String getFileName1(Result result) {
+        return this.getJavaClassName(result);
+    }
+
+    @Override
+    protected String[] getEnv(Result result, String defaultTimeout) {
+        List<String> env = new ArrayList<>();
+
+        env.add("EXECUTION_TIMEOUT=" + getTimeoutEnv(result, defaultTimeout));
+        env.add("FILENAME2=" + getFileName2(result, getFileExtension()));
+        env.add("FILENAME1=" + getFileName1(result));
+        env.add("MEMORYLIMIT=" + "-Xmx" + result.getMaxMemory() + "m");
+
+        return env.toArray(new String[0]);
+    }
+
+    @Override
+    protected String getFileName2(Result result, String fileExtension) {
+        return this.getJavaClassName(result);
+    }
+
+    @Override
+    protected void setSignals(Result result, CreateContainerResponse container) throws IOException {
+        String signalEjecutor = copiarArchivoDeContenedor(container.getId(), "root/signalEjecutor.txt");
+        result.setSignalEjecutor(signalEjecutor);
+
+        String signalCompilador = copiarArchivoDeContenedor(container.getId(), "root/signalCompilador.txt");
+        result.setSignalCompilador(signalCompilador);
+    }
+
+    private String getJavaClassName(Result result) {
+        Matcher publicClassMatcher = Pattern.compile("public\\s+class\\s+([a-zA-Z_$][a-zA-Z_$0-9]*)")
+                .matcher(result.getCodigo());
+        Matcher privateClassMatcher = Pattern.compile("class\\s+([a-zA-Z_$][a-zA-Z_$0-9]*)")
+                .matcher(result.getCodigo());
+
+        if (publicClassMatcher.find()) { return publicClassMatcher.group(1); }
+        else if (privateClassMatcher.find()) { return privateClassMatcher.group(1); }
+
+        return "";
+    }
+}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerPython.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/docker/DockerContainerPython.java
@@ -1,0 +1,56 @@
+package es.urjc.etsii.grafo.iudex.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import es.urjc.etsii.grafo.iudex.entities.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DockerContainerPython extends DockerContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(DockerContainerPython.class);
+
+    public DockerContainerPython(DockerClient dockerClient) {
+        super(dockerClient);
+    }
+
+    @Override
+    protected String getClassName(Result result) {
+        return result.getFileName();
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return "py";
+    }
+
+    @Override
+    protected String getFileName1(Result result) {
+        return result.getFileName();
+    }
+
+    @Override
+    protected String[] getEnv(Result result, String defaultTimeout) {
+        List<String> env = new ArrayList<>();
+
+        env.add("EXECUTION_TIMEOUT=" + getTimeoutEnv(result, defaultTimeout));
+        env.add("FILENAME2=" + getFileName2(result, getFileExtension()));
+
+        return env.toArray(new String[0]);
+    }
+
+    @Override
+    protected String getFileName2(Result result, String fileExtension) {
+        return result.getFileName() + "." + fileExtension;
+    }
+
+    @Override
+    protected void setSignals(Result result, CreateContainerResponse container) throws IOException {
+        String signal = copiarArchivoDeContenedor(container.getId(), "root/signal.txt");
+        result.setSignalEjecutor(signal);
+    }
+}

--- a/src/main/java/es/urjc/etsii/grafo/iudex/services/ResultHandler.java
+++ b/src/main/java/es/urjc/etsii/grafo/iudex/services/ResultHandler.java
@@ -7,8 +7,7 @@ import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.core.command.BuildImageResultCallback;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
-import es.urjc.etsii.grafo.iudex.docker.DockerContainer;
-import es.urjc.etsii.grafo.iudex.docker.DockerContainerMySQL;
+import es.urjc.etsii.grafo.iudex.docker.DockerContainerFactory;
 import es.urjc.etsii.grafo.iudex.entities.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,11 +52,8 @@ public class ResultHandler {
     }
 
     public void ejecutor(Result res) throws IOException, InterruptedException {
-        if (res.getLanguage().getNombreLenguaje().equals("sql")) {
-            new DockerContainerMySQL(dockerClient).ejecutar(res, memoryLimit, timeoutTime, defaultCPU, res.getLanguage().getImgenId());
-        } else {
-            new DockerContainer(dockerClient).ejecutar(res, memoryLimit, timeoutTime, defaultCPU, res.getLanguage().getImgenId());
-        }
+        DockerContainerFactory.createDockerContainerForResult(res, dockerClient)
+                .ejecutar(res, memoryLimit, timeoutTime, defaultCPU, res.getLanguage().getImgenId());
     }
 
     public String buildImage(File file) {


### PR DESCRIPTION
Se ha aplicado dicho patrón para facilitar la introducción de nuevos lenguajes en la aplicación, pero sin tener código duplicado en la aplicación. De esta manera, para añadir un nuevo lenguaje, tan solo sería necesario añadir una nueva clase DockerContainer<Nombre_del_lenguaje> que herede de la clase abstracta DockerContainer y modificar aquellos métodos que sea necesario para ejecutar adecuadamente el contenedor. 

Asimismo, se tienen como ejemplos los DockerContainer de los lenguajes ya introducidos en la aplicación, como lo son:

* DockerContainerJava
* DockerContainerPython
* DockerContainerCPP
* DockerContainerC
* DockerContainerMySQL

Finalmente, cabe destacar que DockerContainerMySQL es la única clase que sobreescribe el método ejecutar() por su gran diferencia con el resto de lenguajes.

Nota: es necesaria la aprobación de la PR #164 para probar su funcionamiento.